### PR TITLE
work around wrong isoft on wandb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,6 @@ dev-dependencies = [
     "pytest>=8.3.3",
     "torchvision>=0.19.1",
 ]
+
+[tool.ruff.isort]
+known-third-party = ["wandb"]


### PR DESCRIPTION
Ruff miss sort wandb as source module after wandb logs folder exists. This is a temporary workaround.