### PR TITLE
set start method only necessary

### DIFF
--- a/fedmind/server.py
+++ b/fedmind/server.py
@@ -79,7 +79,8 @@ class FedAlg:
         """
 
         # Create queues for task distribution and result collection
-        mp.set_start_method("spawn")
+        if mp.get_start_method(allow_none=True) is None:
+            mp.set_start_method("spawn")
         self._task_queue = mp.Queue()
         self._result_queue = mp.Queue()
         self._test_queue = mp.Queue()


### PR DESCRIPTION
The start method can only be set once in a program. Incase it has been set elsewhere, check before setting it to spawn.