### PR TITLE
Config torch for all platform except macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,10 @@ dev-dependencies = [
     "torchvision>=0.19.1",
 ]
 
-[tool.ruff.lint.isort]
-known-third-party = ["wandb"]
+[tool.uv.sources]
+torch = [{ index = "pytorch-cu121", marker = "platform_system != 'Darwin'" }]
+
+[[tool.uv.index]]
+name = "pytorch-cu121"
+url = "https://download.pytorch.org/whl/cu121"
+explicit = true


### PR DESCRIPTION
Use CUDA version torch for Linux and Windows. For macos, the default is the CPU version.